### PR TITLE
fix: add dynamic data to assigned, open  and incident by service

### DIFF
--- a/src/components/IncidentRow.tsx
+++ b/src/components/IncidentRow.tsx
@@ -1,4 +1,4 @@
-import { Component } from 'solid-js'
+import { Component, Show } from 'solid-js'
 import { useNavigate } from 'solid-app-router'
 import { format } from 'date-fns'
 

--- a/src/components/IncidentSeverityIcons.tsx
+++ b/src/components/IncidentSeverityIcons.tsx
@@ -1,6 +1,7 @@
+import { Component } from 'solid-js'
 import { IncidentSeverity } from '../types/incident'
 
-export const CriticalIncidentSeverityIcon = () => (
+export const CriticalIncidentSeverityIcon: Component = () => (
   <div
     title="Critical Severity"
     class="flex justify-center items-center bg-zinc-500 font-bold text-zinc-800 rounded w-4 h-4"
@@ -9,7 +10,7 @@ export const CriticalIncidentSeverityIcon = () => (
   </div>
 )
 
-export const HighIncidentSeverityIcon = () => (
+export const HighIncidentSeverityIcon: Component = () => (
   <div title="High Severity" class="flex items-end space-x-1 w-4 h-4">
     <div class="h-1/3 w-1 bg-zinc-500 rounded-sm"></div>
     <div class="h-2/3 w-1 bg-zinc-500 rounded-sm"></div>
@@ -17,7 +18,7 @@ export const HighIncidentSeverityIcon = () => (
   </div>
 )
 
-export const MediumIncidentSeverityIcon = () => (
+export const MediumIncidentSeverityIcon: Component = () => (
   <div title="Medium Severity" class="flex items-end space-x-1 w-4 h-4">
     <div class="h-1/3 w-1 bg-zinc-500 rounded-sm"></div>
     <div class="h-2/3 w-1 bg-zinc-500 rounded-sm"></div>
@@ -25,7 +26,7 @@ export const MediumIncidentSeverityIcon = () => (
   </div>
 )
 
-export const LowIncidentSeverityIcon = () => (
+export const LowIncidentSeverityIcon: Component = () => (
   <div title="Low Severity" class="flex items-end space-x-1 w-4 h-4">
     <div class="h-1/3 w-1 bg-zinc-500 rounded-sm"></div>
     <div class="h-2/3 w-1 bg-zinc-700 rounded-sm"></div>
@@ -33,7 +34,9 @@ export const LowIncidentSeverityIcon = () => (
   </div>
 )
 
-export const getIncidentSeverityIcon = (severity: IncidentSeverity) => {
+export const getIncidentSeverityIcon = (
+  severity: IncidentSeverity
+): Component => {
   switch (severity) {
     case IncidentSeverity.CRITICAL:
       return CriticalIncidentSeverityIcon
@@ -42,6 +45,7 @@ export const getIncidentSeverityIcon = (severity: IncidentSeverity) => {
     case IncidentSeverity.MEDIUM:
       return MediumIncidentSeverityIcon
     case IncidentSeverity.LOW:
+    default:
       return LowIncidentSeverityIcon
   }
 }

--- a/src/pages/incidents/assigned.tsx
+++ b/src/pages/incidents/assigned.tsx
@@ -8,7 +8,7 @@ import { createQuery } from 'solid-urql'
 
 const GET_ASSIGNED_INCIDENTS = `
   query {
-    incidentsByAssignedId {
+    assignedIncidents {
       id
       description
       status
@@ -20,11 +20,11 @@ const GET_ASSIGNED_INCIDENTS = `
 `
 
 const AssignedIncidents: Component = () => {
-  const [incidentsByAssignedIdResult] = createQuery({
+  const [assignedIncidentsResult] = createQuery({
     query: GET_ASSIGNED_INCIDENTS,
   })
 
-  const incidents = () => incidentsByAssignedIdResult()?.incidentsByAssignedId
+  const incidents = () => assignedIncidentsResult()?.assignedIncidents
 
   return (
     <AppLayout>

--- a/src/pages/incidents/assigned.tsx
+++ b/src/pages/incidents/assigned.tsx
@@ -4,40 +4,33 @@ import IncidentsSidebar from '../../components/IncidentsSidebar'
 import AppLayout from '../../components/layouts/AppLayout'
 import { Incident, IncidentSeverity } from '../../types/incident'
 import IncidentsTable from '../../components/IncidentsTable'
+import { createQuery } from 'solid-urql'
 
-const INCIDENTS = [
-  {
-    id: 'BAT-1',
-    title: 'Incident 1',
-    incidentDate: new Date(),
-    severity: IncidentSeverity.HIGH,
-  },
-  {
-    id: 'BAT-2',
-    title: 'Incident 2',
-    incidentDate: new Date(),
-    severity: IncidentSeverity.MEDIUM,
-  },
-  {
-    id: 'BAT-3',
-    title: 'Incident 3',
-    incidentDate: new Date(),
-    severity: IncidentSeverity.CRITICAL,
-  },
-  {
-    id: 'BAT-4',
-    title: 'Incident 4',
-    incidentDate: new Date(),
-    severity: IncidentSeverity.LOW,
-  },
-] as Incident[]
+const GET_ASSIGNED_INCIDENTS = `
+  query {
+    incidentsByAssignedId {
+      id
+      description
+      status
+      title
+      incidentDate
+      severity
+    }
+  }
+`
 
 const AssignedIncidents: Component = () => {
+  const [incidentsByAssignedIdResult] = createQuery({
+    query: GET_ASSIGNED_INCIDENTS,
+  })
+
+  const incidents = () => incidentsByAssignedIdResult()?.incidentsByAssignedId
+
   return (
     <AppLayout>
       <main class="grid gap-4 grid-cols-4">
         <IncidentsSidebar />
-        {/* <IncidentsTable incidents={()=> {incidents: INCIDENTS}} /> */}
+        <IncidentsTable incidents={incidents} />
       </main>
     </AppLayout>
   )

--- a/src/pages/incidents/open.tsx
+++ b/src/pages/incidents/open.tsx
@@ -3,13 +3,32 @@ import { Component } from 'solid-js'
 import AppLayout from '../../components/layouts/AppLayout'
 import IncidentsTable from '../../components/IncidentsTable'
 import IncidentsSidebar from '../../components/IncidentsSidebar'
+import { createQuery } from 'solid-urql'
 
+const GET_OPEN_INCIDENTS = `
+  query {
+    openIncidents {
+      id
+      description
+      status
+      title
+      incidentDate
+      severity
+    }
+  }
+`
 const OpenIncidents: Component = () => {
+  const [incidentsByOpenResult] = createQuery({
+    query: GET_OPEN_INCIDENTS,
+  })
+
+  const incidents = () => incidentsByOpenResult()?.openIncidents
+
   return (
     <AppLayout>
       <main class="grid gap-4 grid-cols-4">
         <IncidentsSidebar />
-        {/* <IncidentsTable incidents={[]} /> */}
+        <IncidentsTable incidents={incidents} />
       </main>
     </AppLayout>
   )

--- a/src/pages/incidents/open.tsx
+++ b/src/pages/incidents/open.tsx
@@ -17,6 +17,7 @@ const GET_OPEN_INCIDENTS = `
     }
   }
 `
+
 const OpenIncidents: Component = () => {
   const [incidentsByOpenResult] = createQuery({
     query: GET_OPEN_INCIDENTS,

--- a/src/pages/incidents/service.tsx
+++ b/src/pages/incidents/service.tsx
@@ -1,15 +1,65 @@
-import { Component } from 'solid-js'
+import {
+  Component,
+  createEffect,
+  createRenderEffect,
+  createResource,
+  createSignal,
+} from 'solid-js'
+import { createQuery, useClient } from 'solid-urql'
+import { useParams } from 'solid-app-router'
 
 import IncidentsSidebar from '../../components/IncidentsSidebar'
 import IncidentsTable from '../../components/IncidentsTable'
 import AppLayout from '../../components/layouts/AppLayout'
 
+const GET_INCIDENTS_BY_SERVICES = `
+  query($id: ID!) {
+    incidentsByServiceId(serviceId: $id) {
+      id
+      description
+      status
+      title
+      incidentDate
+      severity
+    }
+  }
+`
 const Incidents: Component = () => {
+  const params = useParams()
+  const [getId, setId] = createSignal(params.id)
+  const client = useClient()
+  const variables = () => ({
+    id: params.id,
+  })
+  const [incidentsByServiceResult, eyyyyy, reexecuteQuery] = createQuery({
+    query: GET_INCIDENTS_BY_SERVICES,
+    variables: {
+      id: params.id,
+    },
+  })
+  createEffect(async () => {
+    if (params.id !== getId()) {
+      console.log('fuck you', params.id)
+      reexecuteQuery()
+      console.log(incidentsByServiceResult(), eyyyyy(), reexecuteQuery())
+    }
+    setId(params.id)
+  })
+
+  // createRenderEffect(() => {
+  //   console.log(params.id)
+  //   setId(params.id)
+  //   reexecuteQuery({
+  //     requestPolicy: 'network-only',
+  //     variables: { id: getId() },
+  //   })
+  // })
+  const incidents = () => incidentsByServiceResult()?.incidentsByServiceId
   return (
     <AppLayout>
       <main class="grid gap-4 grid-cols-4">
         <IncidentsSidebar />
-        {/* <IncidentsTable incidents={[]} /> */}
+        <IncidentsTable incidents={incidents} />
       </main>
     </AppLayout>
   )


### PR DESCRIPTION
This PR:

- [x] Adds dynamic data to assigned incidents page, open incidents page, and lists all incidents for service page